### PR TITLE
Added new algorithm for clothing suggestion

### DIFF
--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/MainActivity.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/MainActivity.java
@@ -135,10 +135,10 @@ public class MainActivity extends AppCompatActivity implements MainActivityView 
     @Override
     public void displayYouShouldWearText(int clothing) {
         if (clothing == MainActivityPresenter.PANTS) {
-            shouldWearTextView.setText("You should wear pants today");
+            shouldWearTextView.setText("For the next few hours, it feels like pants weather");
         }
         else if (clothing == MainActivityPresenter.SHORTS) {
-            shouldWearTextView.setText("You should wear shorts today");
+            shouldWearTextView.setText("For the next few hours, it feels like shorts weather");
         }
         shouldWearTextView.invalidate();
     }

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/ForecastResponse.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/ForecastResponse.java
@@ -5,17 +5,29 @@ import java.util.List;
 class ForecastResponse {
     CurrentlyResponse currently;
     DailyResponse daily;
+    HourlyResponse hourly;
 }
 
 class CurrentlyResponse {
     Double temperature;
+    Double apparentTemperature;
 }
 
 class DailyResponse {
     List<DayResponse> data;
 }
 
+class HourlyResponse {
+    List<HourResponse> data;
+}
+
+class HourResponse {
+    Double apparentTemperature;
+}
+
 class DayResponse {
     Double temperatureMax;
     Double temperatureMin;
+    Double apparentTemperatureMax;
+    Double apparentTemperatureMin;
 }

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/MainActivityPresenter.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/MainActivityPresenter.java
@@ -12,7 +12,6 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
-import android.support.v4.widget.SlidingPaneLayout;
 import android.util.Log;
 
 import com.cobresun.brun.pantsorshorts.R;
@@ -68,7 +67,7 @@ public class MainActivityPresenter {
 
     private boolean weatherCallInProgress;
 
-    private int[] hourlyTemps = new int[24 + HOURS_SPENT_OUT + 1];
+    private int[] hourlyTemps = new int[24];
 
     private Context mContext;
     private MainActivityView view;
@@ -101,9 +100,9 @@ public class MainActivityPresenter {
         int curTime = getHour();
         int average = 0;
 
-        int dayEnd = Math.max(AVERAGE_HOME_TIME, curTime+HOURS_SPENT_OUT);
+        int hoursToInclude = Math.max(HOURS_SPENT_OUT, AVERAGE_HOME_TIME - curTime);
 
-        for (int i = curTime; i < dayEnd; i++){
+        for (int i = 0; i < hoursToInclude; i++){
             if (hourlyTemps[i] >= preference) {
                 average++;
             } else {
@@ -276,7 +275,7 @@ public class MainActivityPresenter {
                     highTemp = round(response.body().daily.data.get(0).apparentTemperatureMax);
                     lowTemp = round(response.body().daily.data.get(0).apparentTemperatureMin);
 
-                    for (int i = 0; i < 24 + HOURS_SPENT_OUT + 1; i++){
+                    for (int i = 0; i < hourlyTemps.length; i++){
                         hourlyTemps[i] = round(response.body().hourly.data.get(i).apparentTemperature);
                     }
 

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/WeatherAPIService.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/WeatherAPIService.java
@@ -5,6 +5,6 @@ import retrofit2.http.GET;
 import retrofit2.http.Path;
 
 public interface WeatherAPIService {
-    @GET("forecast/{appid}/{lat},{lon}?exclude=minutely,hourly,alerts,flags&units=ca")
+    @GET("forecast/{appid}/{lat},{lon}?exclude=minutely,alerts,flags&units=ca")
     Call<ForecastResponse> getTemp(@Path("appid") String appid, @Path("lat") double lat, @Path("lon") double lon);
 }

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/UserDataRepository.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/UserDataRepository.java
@@ -2,9 +2,9 @@ package com.cobresun.brun.pantsorshorts.repositories;
 
 public interface UserDataRepository {
 
-    float readUserThreshold();
+    int readUserThreshold();
 
-    void writeUserThreshold(float threshold);
+    void writeUserThreshold(int threshold);
 
     long readLastTimeFetchedWeather();
 
@@ -21,6 +21,10 @@ public interface UserDataRepository {
     int readLastFetchedTempLow();
 
     void writeLastFetchedTempLow(int temp);
+
+    int[] readLastFetchedHourlyTemps();
+
+    void writeLastFetchedHourlyTemps(int[] temps);
 
     boolean isFirstTimeLaunching();
 

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/impl/SharedPrefsUserDataRepository.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/impl/SharedPrefsUserDataRepository.java
@@ -3,7 +3,6 @@ package com.cobresun.brun.pantsorshorts.repositories.impl;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import com.cobresun.brun.pantsorshorts.presenter.MainActivityPresenter;
 import com.cobresun.brun.pantsorshorts.repositories.UserDataRepository;
 
 public class SharedPrefsUserDataRepository implements UserDataRepository {
@@ -98,7 +97,7 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
     @Override
     public int[] readLastFetchedHourlyTemps() {
         int defaultTemp = 10000;
-        int[] temps = new int[24 + MainActivityPresenter.HOURS_SPENT_OUT + 1];
+        int[] temps = new int[24];
         SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         for (int i = 0; i < temps.length; i++){
             temps[i] = settings.getInt("tempHourlyLastFetched" + i, defaultTemp);

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/impl/SharedPrefsUserDataRepository.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/impl/SharedPrefsUserDataRepository.java
@@ -3,6 +3,7 @@ package com.cobresun.brun.pantsorshorts.repositories.impl;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.cobresun.brun.pantsorshorts.presenter.MainActivityPresenter;
 import com.cobresun.brun.pantsorshorts.repositories.UserDataRepository;
 
 public class SharedPrefsUserDataRepository implements UserDataRepository {
@@ -20,17 +21,17 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
     }
 
     @Override
-    public float readUserThreshold() {
-        float defaultThreshold = 21f;
+    public int readUserThreshold() {
+        int defaultThreshold = 21;
         SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        return settings.getFloat("userThreshold", defaultThreshold);
+        return settings.getInt("userThreshold", defaultThreshold);
     }
 
     @Override
-    public void writeUserThreshold(float threshold) {
+    public void writeUserThreshold(int threshold) {
         SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
-        editor.putFloat("userThreshold", threshold);
+        editor.putInt("userThreshold", threshold);
         editor.apply();
     }
 
@@ -91,6 +92,27 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
         SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt("tempLowLastFetched", temp);
+        editor.apply();
+    }
+
+    @Override
+    public int[] readLastFetchedHourlyTemps() {
+        int defaultTemp = 10000;
+        int[] temps = new int[24 + MainActivityPresenter.HOURS_SPENT_OUT + 1];
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        for (int i = 0; i < temps.length; i++){
+            temps[i] = settings.getInt("tempHourlyLastFetched" + i, defaultTemp);
+        }
+        return temps;
+    }
+
+    @Override
+    public void writeLastFetchedHourlyTemps(int[] temps) {
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = settings.edit();
+        for (int i = 0; i < temps.length; i++){
+            editor.putInt("tempHourlyLastFetched" + i, temps[i]);
+        }
         editor.apply();
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,8 +10,8 @@
 
     <TextView
         android:id="@+id/shouldWearTextView"
-        android:layout_width="wrap_content"
-        android:layout_height="26dp"
+        android:layout_width="319dp"
+        android:layout_height="75dp"
         android:layout_marginStart="55dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="30dp"
@@ -20,12 +20,12 @@
         android:textSize="18sp"
         app:layout_constraintBottom_toTopOf="@+id/clothingImageView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.04"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.925" />
+        app:layout_constraintVertical_bias="0.968" />
 
 
     <ImageView


### PR DESCRIPTION
The algorithm now only suggests shorts if it is shorts weather for half or more of the day. 

A day has two definitions depending on when the app is checked. If checked in the morning, the app will assume a typical 'work' day and do the ratio from the current time to a standard home arrival time of 6 pm. Otherwise, it will do the ratio for the next 4 hours. These two values are easily adjustable in the code.

I also added a check for an in-progress api call to ensure extra calls are not sent.

Changed user threshold to be stored as an Integer because why was it stored as a float anyways?

Also with this new way of suggesting, I propose changing the dialog from "You should wear pants today" to "You should put on pants" as the 'today' could be confusing when the app is used in the evening.