### PR TITLE
Fix crash

### DIFF
--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/MainActivity.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/MainActivity.java
@@ -77,6 +77,8 @@ public class MainActivity extends AppCompatActivity implements MainActivityView 
     @Override
     public void updateView() {
         presenter = new MainActivityPresenter(this, new SharedPrefsUserDataRepository(getApplicationContext()), getApplicationContext());
+        // ***** Hacky fix to solve current crash, can probably remove in the future  ***** \\
+        presenter.clearThresholdIfUserUpdatedOrFirstTimeLaunch();
         presenter.checkInternet();
         presenter.createLocationRequest(this);
         presenter.setupNightMode();

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/MainActivityPresenter.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/presenter/MainActivityPresenter.java
@@ -328,4 +328,12 @@ public class MainActivityPresenter {
         }
         return (int) a;
     }
+
+    // ***** This function exists to catch a crash ***** \\
+    public void clearThresholdIfUserUpdatedOrFirstTimeLaunch() {
+        if (userDataRepository.hasUserUpdated()) {
+            userDataRepository.clearUserThreshold();
+            userDataRepository.writeHasUserUpdated(false);
+        }
+    }
 }

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/UserDataRepository.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/UserDataRepository.java
@@ -2,6 +2,12 @@ package com.cobresun.brun.pantsorshorts.repositories;
 
 public interface UserDataRepository {
 
+    boolean hasUserUpdated();
+
+    void writeHasUserUpdated(boolean userUpdated);
+
+    void clearUserThreshold();
+
     int readUserThreshold();
 
     void writeUserThreshold(int threshold);

--- a/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/impl/SharedPrefsUserDataRepository.java
+++ b/app/src/main/java/com/cobresun/brun/pantsorshorts/repositories/impl/SharedPrefsUserDataRepository.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 
 import com.cobresun.brun.pantsorshorts.repositories.UserDataRepository;
 
+import static android.content.Context.MODE_PRIVATE;
+
 public class SharedPrefsUserDataRepository implements UserDataRepository {
 
     // int HowTheyFelt types
@@ -19,16 +21,43 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
         this.context = context;
     }
 
+    // ***** These functions exist purely to escape a current crash ***** \\
+
+    @Override
+    public boolean hasUserUpdated() {
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        return settings.getBoolean("hasUserUpdated", true);
+    }
+
+    @Override
+    public void writeHasUserUpdated(boolean userUpdated) {
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putBoolean("hasUserUpdated", userUpdated);
+        editor.apply();
+    }
+
+    @Override
+    public void clearUserThreshold() {
+        int defaultThreshold = 21;
+        SharedPreferences pref = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        SharedPreferences.Editor editor = pref.edit();
+        editor.putInt("userThreshold", defaultThreshold);
+        editor.apply();
+    }
+
+    // ***** These functions exist purely to escape a current crash ***** \\
+
     @Override
     public int readUserThreshold() {
         int defaultThreshold = 21;
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         return settings.getInt("userThreshold", defaultThreshold);
     }
 
     @Override
     public void writeUserThreshold(int threshold) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt("userThreshold", threshold);
         editor.apply();
@@ -37,13 +66,13 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
     @Override
     public long readLastTimeFetchedWeather() {
         long defaultTime = System.currentTimeMillis();
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         return settings.getLong("timeLastFetched", defaultTime);
     }
 
     @Override
     public void writeLastTimeFetchedWeather(long time) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putLong("timeLastFetched", time);
         editor.apply();
@@ -52,13 +81,13 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
     @Override
     public int readLastFetchedTemp() {
         int defaultTemp = 1000;
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         return settings.getInt("tempLastFetched", defaultTemp);
     }
 
     @Override
     public void writeLastFetchedTemp(int temp) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt("tempLastFetched", temp);
         editor.apply();
@@ -67,13 +96,13 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
     @Override
     public int readLastFetchedTempHigh() {
         int defaultTemp = 1000;
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         return settings.getInt("tempHighLastFetched", defaultTemp);
     }
 
     @Override
     public void writeLastFetchedTempHigh(int temp) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt("tempHighLastFetched", temp);
         editor.apply();
@@ -82,13 +111,13 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
     @Override
     public int readLastFetchedTempLow() {
         int defaultTemp = 1000;
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         return settings.getInt("tempLowLastFetched", defaultTemp);
     }
 
     @Override
     public void writeLastFetchedTempLow(int temp) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt("tempLowLastFetched", temp);
         editor.apply();
@@ -98,7 +127,7 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
     public int[] readLastFetchedHourlyTemps() {
         int defaultTemp = 10000;
         int[] temps = new int[24];
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         for (int i = 0; i < temps.length; i++){
             temps[i] = settings.getInt("tempHourlyLastFetched" + i, defaultTemp);
         }
@@ -107,7 +136,7 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
 
     @Override
     public void writeLastFetchedHourlyTemps(int[] temps) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         for (int i = 0; i < temps.length; i++){
             editor.putInt("tempHourlyLastFetched" + i, temps[i]);
@@ -117,7 +146,7 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
 
     @Override
     public boolean isFirstTimeLaunching() {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         boolean isFirstTime =  settings.getBoolean("isFirstTime", true);
 
         if (isFirstTime) {
@@ -131,13 +160,13 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
 
     @Override
     public boolean isNightMode() {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         return settings.getBoolean("isNightMode", false);
     }
 
     @Override
     public void writeNightMode(boolean nightMode) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putBoolean("isNightMode", nightMode);
         editor.apply();
@@ -145,13 +174,13 @@ public class SharedPrefsUserDataRepository implements UserDataRepository {
 
     @Override
     public boolean isCelsius() {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         return settings.getBoolean("isCelsius", false);
     }
 
     @Override
     public void writeIsCelsius(boolean isCelsius) {
-        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putBoolean("isCelsius", isCelsius);
         editor.apply();

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -189,9 +189,9 @@
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"
         android:contentDescription="@string/night_mode_content_desc"
-        app:layout_constraintBottom_toBottomOf="@+id/temperature"
+        app:layout_constraintBottom_toBottomOf="@+id/slash"
         app:layout_constraintEnd_toStartOf="@+id/nightModeSwitch"
-        app:layout_constraintTop_toTopOf="@+id/city_name"
+        app:layout_constraintTop_toTopOf="@+id/temperature"
         app:srcCompat="@drawable/ic_brightness_contrast" />
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
The idea behind this fix is that for this update, we might as well reset the conflicting integer/float issue by literally resetting the threshold value if its the first time the user is using this version of the app...

I haven't tested this and cannot figure out how to because the emulators don't even seem to be running into the crash in the first place? Would be good to test this PR locally and make sure you don't crash, and then we can pull this into the beta and see if we can replicate any crashes there... 